### PR TITLE
fix: prevent automerging PRs until stabilityDays have passed

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -13,7 +13,7 @@
   rangeStrategy: 'bump',
   // Set a status check pending for 3 days from release timestamp to guard against unpublishing
   stabilityDays: 3,
-  // Renovate will hold back from creating branches until the stabilityDays have passed
+  // Renovate will hold back from creating PRs until the stabilityDays have passed
   // Since we use platformAutomerge, this is important to prevent directly automerging PRs before the stabilityDays have passed
   // Note: we can't use the branch protection for this, because we'd need that check only for renovate PRs
   internalChecksFilter: 'strict',

--- a/default.json5
+++ b/default.json5
@@ -13,6 +13,10 @@
   rangeStrategy: 'bump',
   // Set a status check pending for 3 days from release timestamp to guard against unpublishing
   stabilityDays: 3,
+  // Renovate will hold back from creating branches until the stabilityDays have passed
+  // Since we use platformAutomerge, this is important to prevent directly automerging PRs before the stabilityDays have passed
+  // Note: we can't use the branch protection for this, because we'd need that check only for renovate PRs
+  internalChecksFilter: 'strict',
   // Disable vulnerability updates for now
   // Dependabot is handling them instead because Renovate is not yet able to update transitive dependencies
   // See https://github.com/renovatebot/renovate/issues/3080


### PR DESCRIPTION
I noticed a PR was merged before the stabilityDays had passed:
https://github.com/valora-inc/identity-service/pull/35

It was open 5 days ago, and directly merged without waiting for the stability days.

This should fix this.