### PR TITLE
feat: don't wait for stability days for valora packages

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -110,9 +110,10 @@
       stabilityDays: 0,
     },
 
-    // Disable stability days for Renovate since it's automatically published daily
-    // so has no chance to get merged with the value we set earlier
+    // Disable stability days for some packages, where we don't expect unpublishing
+    // so they are pulled in immediately
     {
+      matchPackagePatterns: ['^@valora/'],
       matchPackageNames: ['renovate'],
       stabilityDays: 0,
     },


### PR DESCRIPTION
Now that we're [automatically publishing some valora packages](https://github.com/valora-inc/logging/pull/5), we don't want to wait for them to be pulled in by Renovate.