### PR TITLE
chore: leave major @types/node updates alone

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -52,6 +52,14 @@
       enabled: false,
     },
 
+    // Leave major @types/node updates alone
+    // We only want to update these when we also update the node version
+    {
+      matchUpdateTypes: ['major'],
+      matchPackageNames: ['@types/node'],
+      enabled: false,
+    },
+
     // Group devDependencies updates
     {
       matchDepTypes: ['devDependencies'],


### PR DESCRIPTION
`@types/node` major version should use the same major version as `node`. Which is version 16 today for us.

This would prevent unwanted `@types/node` upgrades like in https://github.com/valora-inc/address-metadata/pull/66

Discussed at our last eng team meeting: https://docs.google.com/presentation/d/1QQIRY7r_q3n4gS_y0RD-Z9tMNUMpvy_gnGlkZUbECeg/edit#slide=id.g18fddf64cdd_0_10

Part of the work to enable automerge even for major updates.