### PR TITLE
chore(ethers): group ethers and packages that depend on it

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -128,5 +128,15 @@
       matchPackageNames: ['renovate'],
       stabilityDays: 0,
     },
+
+    {
+      matchPackagePatterns: [
+        'ethers',
+        '@fiatconnect/fiatconnect-sdk',
+        'siwe',
+        '@valora/express-siwe',
+      ],
+      groupName: 'ethers and packages that depend on it',
+    },
   ],
 }


### PR DESCRIPTION
- [x] I used `default.json5` for configs that are easy to override (e.g. [mergeable](https://docs.renovatebot.com/configuration-options/) is false), and `base.json5` for all others
