### PR TITLE
chore: avoid `fix` semantic commit type 

### DIFF
--- a/base.json5
+++ b/base.json5
@@ -6,9 +6,9 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   // See https://docs.renovatebot.com/presets-config/#configbase
   extends: ['config:base'],
-  // Avoid "fix" semantic commit type
-  // See https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
-  // https://github.com/renovatebot/renovate/discussions/14026
+  // Restrict semantic commit type to "chore" (avoid "fix")
+  // See: https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
+  //      https://github.com/renovatebot/renovate/discussions/14026
   ignorePresets: [':semanticPrefixFixDepsChoreOthers']
   // UTC is already the default, but for clarity we explicitly set it here
   timezone: 'UTC',

--- a/base.json5
+++ b/base.json5
@@ -9,7 +9,7 @@
   // Restrict semantic commit type to "chore" (avoid "fix")
   // See: https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
   //      https://github.com/renovatebot/renovate/discussions/14026
-  ignorePresets: [':semanticPrefixFixDepsChoreOthers']
+  ignorePresets: [':semanticPrefixFixDepsChoreOthers'],
   // UTC is already the default, but for clarity we explicitly set it here
   timezone: 'UTC',
   // Ignore hourly limit from the base preset

--- a/base.json5
+++ b/base.json5
@@ -6,6 +6,10 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   // See https://docs.renovatebot.com/presets-config/#configbase
   extends: ['config:base'],
+  // Avoid "fix" semantic commit type
+  // See https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
+  // https://github.com/renovatebot/renovate/discussions/14026
+  ignorePresets: [':semanticPrefixFixDepsChoreOthers']
   // UTC is already the default, but for clarity we explicitly set it here
   timezone: 'UTC',
   // Ignore hourly limit from the base preset


### PR DESCRIPTION
Committing regular dependency updates with a `fix` semantic commit type seems misleading because those aren't necessarily fixing anything _in the app_, but mostly keeping the dependencies up to date.

For instance: does the PR below fix anything in the wallet? Not really.
https://github.com/valora-inc/wallet/pull/5749

This aims to restrict renovate updates with a `chore` semantic commit type.

