### PR TITLE
chore: minimum release age

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# valora-inc/renovate-config
+# valora-xyz/renovate-config
 
 Shareable [Renovate](https://renovatebot.com) config for Valora repositories.
 
@@ -10,7 +10,7 @@ Add the following into your `renovate.json5`:
 
 ```json5
 {
-  extends: ['github>valora-inc/renovate-config:default.json5'],
+  extends: ['github>valora-xyz/renovate-config:default.json5'],
 }
 ```
 
@@ -26,7 +26,7 @@ not possible, then the Valora base presets can be used instead as follows:
 
 ```json5
 {
-  extends: ['github>valora-inc/renovate-config:base.json5'],
+  extends: ['github>valora-xyz/renovate-config:base.json5'],
 }
 ```
 
@@ -42,7 +42,7 @@ Examples:
 
 ```json5
 {
-  extends: ['github>valora-inc/renovate-config:default.json5'],
+  extends: ['github>valora-xyz/renovate-config:default.json5'],
   semanticCommits: 'disabled',
 }
 ```
@@ -51,7 +51,7 @@ Examples:
 
 ```json5
 {
-  extends: ['github>valora-inc/renovate-config:default.json5'],
+  extends: ['github>valora-xyz/renovate-config:default.json5'],
   packageRules: [
     {
       matchDepTypes: ['peerDependencies', 'engines'],

--- a/base.json5
+++ b/base.json5
@@ -16,8 +16,8 @@
   ignorePresets: [':prHourlyLimit2'],
   // Bump version ranges instead of pinning since we use lock files
   rangeStrategy: 'bump',
-  // Set a status check pending for 3 days from release timestamp to guard against unpublishing
-  stabilityDays: 3,
+  // Delay updates to reduce risk supply chain security risks
+  minimumReleaseAge: 7 days
   // Automerge all updates (see packageRules below for exceptions)
   automerge: true,
   // Only automerge during weekdays when the team is up, and skip Fridays.

--- a/base.json5
+++ b/base.json5
@@ -17,7 +17,7 @@
   // Bump version ranges instead of pinning since we use lock files
   rangeStrategy: 'bump',
   // Delay updates to reduce risk supply chain security risks
-  minimumReleaseAge: 7 days
+  minimumReleaseAge: '7 days',
   // Automerge all updates (see packageRules below for exceptions)
   automerge: true,
   // Only automerge during weekdays when the team is up, and skip Fridays.

--- a/default.json5
+++ b/default.json5
@@ -1,7 +1,7 @@
 // default renovate config options for Valora repos
 // for configs that are easy/possible to override (e.g. `mergeable` is false), use base.json5 instead. see README for details
 {
-  extends: ['github>valora-inc/renovate-config:base.json5'],
+  extends: ['github>valora-xyz/renovate-config:base.json5'],
 
   // Dedupe dependencies
   postUpdateOptions: ['yarnDedupeFewer'],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@valora-inc/renovate-config",
-  "version": "0.0.1",
+  "name": "@valora-xyz/renovate-config",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "private": true,
   "engines": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,4 +1,4 @@
 {
   // Renovate config for this repo extends our default config
-  extends: ['github>valora-inc/renovate-config:default.json5'],
+  extends: ['github>valora-xyz/renovate-config:default.json5'],
 }


### PR DESCRIPTION
### Description

- Updates the `minimumReleaseAge` to 7 days: [docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/).
- Renames `valora-inc` to `valora-xyz` within the repo.
- Patch version bump. 
